### PR TITLE
Add some features to code builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@httptoolkit/httpsnippet",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@httptoolkit/httpsnippet",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.2.0",
   "name": "@httptoolkit/httpsnippet",
   "description": "HTTP request snippet generator for *most* languages",
   "author": "Tim Perry <tim@httptoolkit.tech>",

--- a/src/helpers/code-builder.js
+++ b/src/helpers/code-builder.js
@@ -11,93 +11,95 @@ const util = require('util')
  * @param {string} indentation Desired indentation character for aggregated lines of code
  * @param {string} join Desired character to join each line of code
  */
-const CodeBuilder = function (indentation, join) {
-  this.code = []
-  this.indentation = indentation
-  this.lineJoin = join || '\n'
-}
-
-/**
- * Add given indentation level to given string and format the string (variadic)
- * @param {number} [indentationLevel=0] - Desired level of indentation for this line
- * @param {string} line - Line of code. Can contain formatting placeholders
- * @param {...anyobject} - Parameter to bind to `line`'s formatting placeholders
- * @return {string}
- *
- * @example
- *   var builder = CodeBuilder('\t')
- *
- *   builder.buildLine('console.log("hello world")')
- *   // returns: 'console.log("hello world")'
- *
- *   builder.buildLine(2, 'console.log("hello world")')
- *   // returns: 'console.log("\t\thello world")'
- *
- *   builder.buildLine(2, 'console.log("%s %s")', 'hello', 'world')
- *   // returns: 'console.log("\t\thello world")'
- */
-CodeBuilder.prototype.buildLine = function (indentationLevel, line) {
-  let lineIndentation = ''
-  let slice = 2
-  if (Object.prototype.toString.call(indentationLevel) === '[object String]') {
-    slice = 1
-    line = indentationLevel
-    indentationLevel = 0
-  } else if (indentationLevel === null) {
-    return null
+class CodeBuilder {
+  constructor (indentation, join) {
+    this.code = []
+    this.indentation = indentation
+    this.lineJoin = join || '\n'
   }
 
-  while (indentationLevel) {
-    lineIndentation += this.indentation
-    indentationLevel--
+  /**
+   * Add given indentation level to given string and format the string (variadic)
+   * @param {number} [indentationLevel=0] - Desired level of indentation for this line
+   * @param {string} line - Line of code. Can contain formatting placeholders
+   * @param {...anyobject} - Parameter to bind to `line`'s formatting placeholders
+   * @return {string}
+   *
+   * @example
+   *   var builder = CodeBuilder('\t')
+   *
+   *   builder.buildLine('console.log("hello world")')
+   *   // returns: 'console.log("hello world")'
+   *
+   *   builder.buildLine(2, 'console.log("hello world")')
+   *   // returns: 'console.log("\t\thello world")'
+   *
+   *   builder.buildLine(2, 'console.log("%s %s")', 'hello', 'world')
+   *   // returns: 'console.log("\t\thello world")'
+   */
+  buildLine (indentationLevel, line) {
+    let lineIndentation = ''
+    let slice = 2
+    if (Object.prototype.toString.call(indentationLevel) === '[object String]') {
+      slice = 1
+      line = indentationLevel
+      indentationLevel = 0
+    } else if (indentationLevel === null) {
+      return null
+    }
+
+    while (indentationLevel) {
+      lineIndentation += this.indentation
+      indentationLevel--
+    }
+
+    const format = Array.prototype.slice.call(arguments, slice, arguments.length)
+    format.unshift(lineIndentation + line)
+
+    return util.format.apply(this, format)
   }
 
-  const format = Array.prototype.slice.call(arguments, slice, arguments.length)
-  format.unshift(lineIndentation + line)
+  /**
+   * Invoke buildLine() and add the line at the top of current lines
+   * @param {number} [indentationLevel=0] Desired level of indentation for this line
+   * @param {string} line Line of code
+   * @return {this}
+   */
+  unshift () {
+    this.code.unshift(this.buildLine.apply(this, arguments))
 
-  return util.format.apply(this, format)
-}
+    return this
+  }
 
-/**
- * Invoke buildLine() and add the line at the top of current lines
- * @param {number} [indentationLevel=0] Desired level of indentation for this line
- * @param {string} line Line of code
- * @return {this}
- */
-CodeBuilder.prototype.unshift = function () {
-  this.code.unshift(this.buildLine.apply(this, arguments))
+  /**
+   * Invoke buildLine() and add the line at the bottom of current lines
+   * @param {number} [indentationLevel=0] Desired level of indentation for this line
+   * @param {string} line Line of code
+   * @return {this}
+   */
+  push () {
+    this.code.push(this.buildLine.apply(this, arguments))
 
-  return this
-}
+    return this
+  }
 
-/**
- * Invoke buildLine() and add the line at the bottom of current lines
- * @param {number} [indentationLevel=0] Desired level of indentation for this line
- * @param {string} line Line of code
- * @return {this}
- */
-CodeBuilder.prototype.push = function () {
-  this.code.push(this.buildLine.apply(this, arguments))
+  /**
+   * Add an empty line at the end of current lines
+   * @return {this}
+   */
+  blank () {
+    this.code.push(null)
 
-  return this
-}
+    return this
+  }
 
-/**
- * Add an empty line at the end of current lines
- * @return {this}
- */
-CodeBuilder.prototype.blank = function () {
-  this.code.push(null)
-
-  return this
-}
-
-/**
- * Concatenate all current lines using the given lineJoin
- * @return {string}
- */
-CodeBuilder.prototype.join = function () {
-  return this.code.join(this.lineJoin)
+  /**
+   * Concatenate all current lines using the given lineJoin
+   * @return {string}
+   */
+  join () {
+    return this.code.join(this.lineJoin)
+  }
 }
 
 module.exports = CodeBuilder

--- a/src/helpers/code-builder.js
+++ b/src/helpers/code-builder.js
@@ -73,7 +73,8 @@ class CodeBuilder {
 
     if (!line) return
 
-    while (indentationLevel) {
+    indentationLevel += this.indentLevel
+    while (indentationLevel > 0) {
       lineIndentation += this.indentation
       indentationLevel--
     }

--- a/src/helpers/code-builder.js
+++ b/src/helpers/code-builder.js
@@ -16,6 +16,34 @@ class CodeBuilder {
     this.code = []
     this.indentation = indentation
     this.lineJoin = join || '\n'
+    this.indentLevel = 0
+  }
+
+  /**
+   * Increase indentation level
+   * @returns {this}
+   */
+  indent () {
+    this.indentLevel++
+    return this
+  }
+
+  /**
+   * Decrease indentation level
+   * @returns {this}
+   */
+  unindent () {
+    this.indentLevel--
+    return this
+  }
+
+  /**
+   * Reset indentation level
+   * @returns {this}
+   */
+  reindent () {
+    this.indentLevel = 0
+    return this
   }
 
   /**

--- a/src/helpers/code-builder.js
+++ b/src/helpers/code-builder.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const util = require('util')
+const formatString = require('./format')
 
 /**
  * Helper object to format and aggragate lines of code.
@@ -62,29 +62,26 @@ class CodeBuilder {
    *   builder.buildLine(2, 'console.log("hello world")')
    *   // returns: 'console.log("\t\thello world")'
    *
-   *   builder.buildLine(2, 'console.log("%s %s")', 'hello', 'world')
+   *   builder.buildLine(2, 'console.log("%q %q")', 'hello', 'world')
    *   // returns: 'console.log("\t\thello world")'
    */
-  buildLine (indentationLevel, line) {
+  buildLine (indentationLevel, line, ...format) {
     let lineIndentation = ''
-    let slice = 2
-    if (Object.prototype.toString.call(indentationLevel) === '[object String]') {
-      slice = 1
-      line = indentationLevel
-      indentationLevel = 0
-    } else if (indentationLevel === null) {
-      return null
+    if (typeof indentationLevel !== 'number') {
+      return this.buildLine(0, ...arguments)
     }
+
+    if (!line) return
 
     while (indentationLevel) {
       lineIndentation += this.indentation
       indentationLevel--
     }
 
-    const format = Array.prototype.slice.call(arguments, slice, arguments.length)
-    format.unshift(lineIndentation + line)
+    // custom format option: escape %q
+    line = lineIndentation + line
 
-    return util.format.apply(this, format)
+    return formatString(line, ...format)
   }
 
   /**

--- a/src/helpers/format.js
+++ b/src/helpers/format.js
@@ -1,0 +1,36 @@
+const util = require('util')
+
+function quote (value) {
+  if (typeof value !== 'string') value = JSON.stringify(value)
+  return JSON.stringify(value)
+}
+
+function escape (value) {
+  const q = quote(value)
+  return q && q.slice(1, -1)
+}
+
+function format (value, ...format) {
+  if (typeof value !== 'string') return ''
+
+  let i = 0
+  value = value.replace(/(?<!%)%[sdifjoOcqv]/g, (m) => {
+    // JSON-stringify
+    if (m === '%v') {
+      const [elem] = format.splice(i, 1)
+      return JSON.stringify(elem)
+    }
+    // JSON-stringify, remove quotes (means, escape)
+    if (m === '%q') {
+      const [elem] = format.splice(i, 1)
+      return escape(elem)
+    }
+    i += 1
+    return m
+  })
+
+  const ret = util.format(value, ...format)
+  return ret
+}
+
+module.exports = format

--- a/src/index.js
+++ b/src/index.js
@@ -15,318 +15,316 @@ const validate = require('har-validator/lib/async')
 const { formDataIterator, isBlob } = require('./helpers/form-data.js')
 
 // constructor
-const HTTPSnippet = function (data) {
-  let entries
-  const self = this
-  const input = Object.assign({}, data)
+class HTTPSnippet {
+  static addTarget (target) {
+    if (!('info' in target)) {
+      throw new Error('The supplied custom target must contain an `info` object.')
+    } else if (!('key' in target.info) || !('title' in target.info) || !('extname' in target.info) || !('default' in target.info)) {
+      throw new Error('The supplied custom target must have an `info` object with a `key`, `title`, `extname`, and `default` property.')
+      // eslint-disable-next-line no-prototype-builtins
+    } else if (targets.hasOwnProperty(target.info.key)) {
+      throw new Error('The supplied custom target already exists.')
+    } else if (Object.keys(target).length === 1) {
+      throw new Error('A custom target must have a client defined on it.')
+    }
 
-  // prep the main container
-  self.requests = []
-
-  // is it har?
-  if (input.log && input.log.entries) {
-    entries = input.log.entries
-  } else {
-    entries = [{
-      request: input
-    }]
+    targets[target.info.key] = target
   }
 
-  entries.forEach(function (entry) {
-    // add optional properties to make validation successful
-    entry.request.httpVersion = entry.request.httpVersion || 'HTTP/1.1'
-    entry.request.queryString = entry.request.queryString || []
-    entry.request.headers = entry.request.headers || []
-    entry.request.cookies = entry.request.cookies || []
-    entry.request.postData = entry.request.postData || {}
-    entry.request.postData.mimeType = entry.request.postData.mimeType || 'application/octet-stream'
+  static addTargetClient (target, client) {
+    // eslint-disable-next-line no-prototype-builtins
+    if (!targets.hasOwnProperty(target)) {
+      throw new Error(`Sorry, but no ${target} target exists to add clients to.`)
+    } else if (!('info' in client)) {
+      throw new Error('The supplied custom target client must contain an `info` object.')
+    } else if (!('key' in client.info) || !('title' in client.info)) {
+      throw new Error('The supplied custom target client must have an `info` object with a `key` and `title` property.')
+      // eslint-disable-next-line no-prototype-builtins
+    } else if (targets[target].hasOwnProperty(client.info.key)) {
+      throw new Error('The supplied custom target client already exists, please use a different key')
+    }
 
-    entry.request.bodySize = 0
-    entry.request.headersSize = 0
-    entry.request.postData.size = 0
-
-    validate.request(entry.request, function (err, valid) {
-      if (!valid) {
-        throw err
-      }
-
-      self.requests.push(self.prepare(entry.request))
-    })
-  })
-}
-
-HTTPSnippet.prototype.prepare = function (request) {
-  // construct utility properties
-  request.queryObj = {}
-  request.headersObj = {}
-  request.cookiesObj = {}
-  request.allHeaders = {}
-  request.postData.jsonObj = false
-  request.postData.paramsObj = false
-
-  // construct query objects
-  if (request.queryString && request.queryString.length) {
-    debug('queryString found, constructing queryString pair map')
-
-    request.queryObj = request.queryString.reduce(reducer, {})
+    targets[target][client.info.key] = client
   }
 
-  // construct headers objects
-  if (request.headers && request.headers.length) {
-    const http2VersionRegex = /^HTTP\/2/
-    request.headersObj = request.headers.reduce(function (headers, header) {
-      let headerName = header.name
-      if (request.httpVersion.match(http2VersionRegex)) {
-        headerName = headerName.toLowerCase()
-      }
-
-      headers[headerName] = header.value
-      return headers
-    }, {})
-  }
-
-  // construct headers objects
-  if (request.cookies && request.cookies.length) {
-    request.cookiesObj = request.cookies.reduceRight(function (cookies, cookie) {
-      cookies[cookie.name] = cookie.value
-      return cookies
-    }, {})
-  }
-
-  // construct Cookie header
-  const cookies = request.cookies.map(function (cookie) {
-    return encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value)
-  })
-
-  if (cookies.length) {
-    request.allHeaders.cookie = cookies.join('; ')
-  }
-
-  switch (request.postData.mimeType) {
-    case 'multipart/mixed':
-    case 'multipart/related':
-    case 'multipart/form-data':
-    case 'multipart/alternative':
-      // reset values
-      request.postData.text = ''
-      request.postData.mimeType = 'multipart/form-data'
-
-      if (request.postData.params) {
-        const form = new MultiPartForm()
-
-        // The `form-data` module returns one of two things: a native FormData object, or its own polyfill. Since the
-        // polyfill does not support the full API of the native FormData object, when this library is running in a
-        // browser environment it'll fail on two things:
-        //
-        //  - The API for `form.append()` has three arguments and the third should only be present when the second is a
-        //    Blob or USVString.
-        //  - `FormData.pipe()` isn't a function.
-        //
-        // Since the native FormData object is iterable, we easily detect what version of `form-data` we're working
-        // with here to allow `multipart/form-data` requests to be compiled under both browser and Node environments.
-        //
-        // This hack is pretty awful but it's the only way we can use this library in the browser as if we code this
-        // against just the native FormData object, we can't polyfill that back into Node because Blob and File objects,
-        // which something like `formdata-polyfill` requires, don't exist there.
-        const isNativeFormData = (typeof form[Symbol.iterator] === 'function')
-
-        // easter egg
-        const boundary = '---011000010111000001101001'
-        if (!isNativeFormData) {
-          form._boundary = boundary
-        }
-
-        request.postData.params.forEach(function (param) {
-          const name = param.name
-          const value = param.value || ''
-          const filename = param.fileName || null
-
-          if (isNativeFormData) {
-            if (isBlob(value)) {
-              form.append(name, value, filename)
-            } else {
-              form.append(name, value)
-            }
-          } else {
-            form.append(name, value, {
-              filename: filename,
-              contentType: param.contentType || null
-            })
-          }
+  static availableTargets () {
+    return Object.keys(targets).map(function (key) {
+      const target = Object.assign({}, targets[key].info)
+      const clients = Object.keys(targets[key])
+        .filter(function (prop) {
+          return !~['info', 'index'].indexOf(prop)
+        })
+        .map(function (client) {
+          return targets[key][client].info
         })
 
-        if (isNativeFormData) {
-          for (const data of formDataIterator(form, boundary)) {
-            request.postData.text += data
-          }
-        } else {
-          // eslint-disable-next-line array-callback-return
-          form.pipe(es.map(function (data, cb) {
-            request.postData.text += data
-          }))
-        }
-
-        request.postData.boundary = boundary
-
-        // Since headers are case-sensitive we need to see if there's an existing `Content-Type` header that we can
-        // override.
-        const contentTypeHeader = helpers.hasHeader(request.headersObj, 'content-type')
-          ? helpers.getHeaderName(request.headersObj, 'content-type')
-          : 'content-type'
-
-        request.headersObj[contentTypeHeader] = 'multipart/form-data; boundary=' + boundary
+      if (clients.length) {
+        target.clients = clients
       }
-      break
 
-    case 'application/x-www-form-urlencoded':
-      if (!request.postData.params) {
-        request.postData.text = ''
-      } else {
-        request.postData.paramsObj = request.postData.params.reduce(reducer, {})
-
-        // always overwrite
-        request.postData.text = qs.stringify(request.postData.paramsObj)
-      }
-      break
-
-    case 'text/json':
-    case 'text/x-json':
-    case 'application/json':
-    case 'application/x-json':
-      request.postData.mimeType = 'application/json'
-
-      if (request.postData.text) {
-        try {
-          request.postData.jsonObj = JSON.parse(request.postData.text)
-        } catch (e) {
-          debug(e)
-
-          // force back to text/plain
-          // if headers have proper content-type value, then this should also work
-          request.postData.mimeType = 'text/plain'
-        }
-      }
-      break
-  }
-
-  // create allHeaders object
-  request.allHeaders = Object.assign(request.allHeaders, request.headersObj)
-
-  // deconstruct the uri
-  // eslint-disable-next-line node/no-deprecated-api
-  request.uriObj = url.parse(request.url, true, true)
-
-  // merge all possible queryString values
-  request.queryObj = Object.assign(request.queryObj, request.uriObj.query)
-
-  // reset uriObj values for a clean url
-  request.uriObj.query = null
-  request.uriObj.search = null
-  request.uriObj.path = request.uriObj.pathname
-
-  // keep the base url clean of queryString
-  request.url = url.format(request.uriObj)
-
-  // update the uri object
-  request.uriObj.query = request.queryObj
-  request.uriObj.search = qs.stringify(request.queryObj)
-
-  if (request.uriObj.search) {
-    request.uriObj.path = request.uriObj.pathname + '?' + request.uriObj.search
-  }
-
-  // construct a full url
-  request.fullUrl = url.format(request.uriObj)
-
-  return request
-}
-
-HTTPSnippet.prototype.convert = function (target, client, opts) {
-  if (!opts && client) {
-    opts = client
-  }
-
-  const func = this._matchTarget(target, client)
-  if (func) {
-    const results = this.requests.map(function (request) {
-      return func(request, opts)
+      return target
     })
-
-    return results.length === 1 ? results[0] : results
   }
 
-  return false
-}
+  static extname (target) {
+    return targets[target] ? targets[target].info.extname : ''
+  }
 
-HTTPSnippet.prototype._matchTarget = function (target, client) {
-  // does it exist?
-  // eslint-disable-next-line no-prototype-builtins
-  if (!targets.hasOwnProperty(target)) {
+  constructor (data) {
+    let entries
+    const input = Object.assign({}, data)
+
+    // prep the main container
+    this.requests = []
+
+    // is it har?
+    if (input.log && input.log.entries) {
+      entries = input.log.entries
+    } else {
+      entries = [{
+        request: input
+      }]
+    }
+
+    entries.forEach((entry) => {
+      // add optional properties to make validation successful
+      entry.request.httpVersion = entry.request.httpVersion || 'HTTP/1.1'
+      entry.request.queryString = entry.request.queryString || []
+      entry.request.headers = entry.request.headers || []
+      entry.request.cookies = entry.request.cookies || []
+      entry.request.postData = entry.request.postData || {}
+      entry.request.postData.mimeType = entry.request.postData.mimeType || 'application/octet-stream'
+
+      entry.request.bodySize = 0
+      entry.request.headersSize = 0
+      entry.request.postData.size = 0
+
+      validate.request(entry.request, (err, valid) => {
+        if (!valid) {
+          throw err
+        }
+
+        this.requests.push(this.prepare(entry.request))
+      })
+    })
+  }
+
+  prepare (request) {
+    // construct utility properties
+    request.queryObj = {}
+    request.headersObj = {}
+    request.cookiesObj = {}
+    request.allHeaders = {}
+    request.postData.jsonObj = false
+    request.postData.paramsObj = false
+
+    // construct query objects
+    if (request.queryString && request.queryString.length) {
+      debug('queryString found, constructing queryString pair map')
+
+      request.queryObj = request.queryString.reduce(reducer, {})
+    }
+
+    // construct headers objects
+    if (request.headers && request.headers.length) {
+      const http2VersionRegex = /^HTTP\/2/
+      request.headersObj = request.headers.reduce(function (headers, header) {
+        let headerName = header.name
+        if (request.httpVersion.match(http2VersionRegex)) {
+          headerName = headerName.toLowerCase()
+        }
+
+        headers[headerName] = header.value
+        return headers
+      }, {})
+    }
+
+    // construct headers objects
+    if (request.cookies && request.cookies.length) {
+      request.cookiesObj = request.cookies.reduceRight(function (cookies, cookie) {
+        cookies[cookie.name] = cookie.value
+        return cookies
+      }, {})
+    }
+
+    // construct Cookie header
+    const cookies = request.cookies.map((cookie) =>
+      encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value))
+
+    if (cookies.length) {
+      request.allHeaders.cookie = cookies.join('; ')
+    }
+
+    switch (request.postData.mimeType) {
+      case 'multipart/mixed':
+      case 'multipart/related':
+      case 'multipart/form-data':
+      case 'multipart/alternative':
+        // reset values
+        request.postData.text = ''
+        request.postData.mimeType = 'multipart/form-data'
+
+        if (request.postData.params) {
+          const form = new MultiPartForm()
+
+          // The `form-data` module returns one of two things: a native FormData object, or its own polyfill. Since the
+          // polyfill does not support the full API of the native FormData object, when this library is running in a
+          // browser environment it'll fail on two things:
+          //
+          //  - The API for `form.append()` has three arguments and the third should only be present when the second is a
+          //    Blob or USVString.
+          //  - `FormData.pipe()` isn't a function.
+          //
+          // Since the native FormData object is iterable, we easily detect what version of `form-data` we're working
+          // with here to allow `multipart/form-data` requests to be compiled under both browser and Node environments.
+          //
+          // This hack is pretty awful but it's the only way we can use this library in the browser as if we code this
+          // against just the native FormData object, we can't polyfill that back into Node because Blob and File objects,
+          // which something like `formdata-polyfill` requires, don't exist there.
+          const isNativeFormData = (typeof form[Symbol.iterator] === 'function')
+
+          // easter egg
+          const boundary = '---011000010111000001101001'
+          if (!isNativeFormData) {
+            form._boundary = boundary
+          }
+
+          request.postData.params.forEach(function (param) {
+            const name = param.name
+            const value = param.value || ''
+            const filename = param.fileName || null
+
+            if (isNativeFormData) {
+              if (isBlob(value)) {
+                form.append(name, value, filename)
+              } else {
+                form.append(name, value)
+              }
+            } else {
+              form.append(name, value, {
+                filename: filename,
+                contentType: param.contentType || null
+              })
+            }
+          })
+
+          if (isNativeFormData) {
+            for (const data of formDataIterator(form, boundary)) {
+              request.postData.text += data
+            }
+          } else {
+            // eslint-disable-next-line array-callback-return
+            form.pipe(es.map(function (data, cb) {
+              request.postData.text += data
+            }))
+          }
+
+          request.postData.boundary = boundary
+
+          // Since headers are case-sensitive we need to see if there's an existing `Content-Type` header that we can
+          // override.
+          const contentTypeHeader = helpers.hasHeader(request.headersObj, 'content-type')
+            ? helpers.getHeaderName(request.headersObj, 'content-type')
+            : 'content-type'
+
+          request.headersObj[contentTypeHeader] = 'multipart/form-data; boundary=' + boundary
+        }
+        break
+
+      case 'application/x-www-form-urlencoded':
+        if (!request.postData.params) {
+          request.postData.text = ''
+        } else {
+          request.postData.paramsObj = request.postData.params.reduce(reducer, {})
+
+          // always overwrite
+          request.postData.text = qs.stringify(request.postData.paramsObj)
+        }
+        break
+
+      case 'text/json':
+      case 'text/x-json':
+      case 'application/json':
+      case 'application/x-json':
+        request.postData.mimeType = 'application/json'
+
+        if (request.postData.text) {
+          try {
+            request.postData.jsonObj = JSON.parse(request.postData.text)
+          } catch (e) {
+            debug(e)
+
+            // force back to text/plain
+            // if headers have proper content-type value, then this should also work
+            request.postData.mimeType = 'text/plain'
+          }
+        }
+        break
+    }
+
+    // create allHeaders object
+    request.allHeaders = Object.assign(request.allHeaders, request.headersObj)
+
+    // deconstruct the uri
+    // eslint-disable-next-line node/no-deprecated-api
+    request.uriObj = url.parse(request.url, true, true)
+
+    // merge all possible queryString values
+    request.queryObj = Object.assign(request.queryObj, request.uriObj.query)
+
+    // reset uriObj values for a clean url
+    request.uriObj.query = null
+    request.uriObj.search = null
+    request.uriObj.path = request.uriObj.pathname
+
+    // keep the base url clean of queryString
+    request.url = url.format(request.uriObj)
+
+    // update the uri object
+    request.uriObj.query = request.queryObj
+    request.uriObj.search = qs.stringify(request.queryObj)
+
+    if (request.uriObj.search) {
+      request.uriObj.path = request.uriObj.pathname + '?' + request.uriObj.search
+    }
+
+    // construct a full url
+    request.fullUrl = url.format(request.uriObj)
+
+    return request
+  }
+
+  convert (target, client, opts) {
+    if (!opts && client) {
+      opts = client
+    }
+
+    const func = this._matchTarget(target, client)
+    if (func) {
+      const results = this.requests.map((request) => func(request, opts))
+
+      return results.length === 1 ? results[0] : results
+    }
+
     return false
   }
 
-  // shorthand
-  if (typeof client === 'string' && typeof targets[target][client] === 'function') {
-    return targets[target][client]
-  }
+  _matchTarget (target, client) {
+    // does it exist?
+    // eslint-disable-next-line no-prototype-builtins
+    if (!targets.hasOwnProperty(target)) {
+      return false
+    }
 
-  // default target
-  return targets[target][targets[target].info.default]
+    // shorthand
+    if (typeof client === 'string' && typeof targets[target][client] === 'function') {
+      return targets[target][client]
+    }
+
+    // default target
+    return targets[target][targets[target].info.default]
+  }
 }
 
 // exports
 module.exports = HTTPSnippet
-
-module.exports.addTarget = function (target) {
-  if (!('info' in target)) {
-    throw new Error('The supplied custom target must contain an `info` object.')
-  } else if (!('key' in target.info) || !('title' in target.info) || !('extname' in target.info) || !('default' in target.info)) {
-    throw new Error('The supplied custom target must have an `info` object with a `key`, `title`, `extname`, and `default` property.')
-  // eslint-disable-next-line no-prototype-builtins
-  } else if (targets.hasOwnProperty(target.info.key)) {
-    throw new Error('The supplied custom target already exists.')
-  } else if (Object.keys(target).length === 1) {
-    throw new Error('A custom target must have a client defined on it.')
-  }
-
-  targets[target.info.key] = target
-}
-
-module.exports.addTargetClient = function (target, client) {
-  // eslint-disable-next-line no-prototype-builtins
-  if (!targets.hasOwnProperty(target)) {
-    throw new Error(`Sorry, but no ${target} target exists to add clients to.`)
-  } else if (!('info' in client)) {
-    throw new Error('The supplied custom target client must contain an `info` object.')
-  } else if (!('key' in client.info) || !('title' in client.info)) {
-    throw new Error('The supplied custom target client must have an `info` object with a `key` and `title` property.')
-  // eslint-disable-next-line no-prototype-builtins
-  } else if (targets[target].hasOwnProperty(client.info.key)) {
-    throw new Error('The supplied custom target client already exists, please use a different key')
-  }
-
-  targets[target][client.info.key] = client
-}
-
-module.exports.availableTargets = function () {
-  return Object.keys(targets).map(function (key) {
-    const target = Object.assign({}, targets[key].info)
-    const clients = Object.keys(targets[key])
-      .filter(function (prop) {
-        return !~['info', 'index'].indexOf(prop)
-      })
-      .map(function (client) {
-        return targets[key][client].info
-      })
-
-    if (clients.length) {
-      target.clients = clients
-    }
-
-    return target
-  })
-}
-
-module.exports.extname = function (target) {
-  return targets[target] ? targets[target].info.extname : ''
-}

--- a/src/targets/clojure/clj_http.js
+++ b/src/targets/clojure/clj_http.js
@@ -13,20 +13,24 @@
 const CodeBuilder = require('../../helpers/code-builder')
 const helpers = require('../../helpers/headers')
 
-const Keyword = function (name) {
-  this.name = name
+class Keyword {
+  constructor (name) {
+    this.name = name
+  }
+
+  toString () {
+    return ':' + this.name
+  }
 }
 
-Keyword.prototype.toString = function () {
-  return ':' + this.name
-}
+class File {
+  constructor (path) {
+    this.path = path
+  }
 
-const File = function (path) {
-  this.path = path
-}
-
-File.prototype.toString = function () {
-  return '(clojure.java.io/file "' + this.path + '")'
+  toString () {
+    return '(clojure.java.io/file "' + this.path + '")'
+  }
 }
 
 const jsType = function (x) {

--- a/src/targets/clojure/clj_http.js
+++ b/src/targets/clojure/clj_http.js
@@ -148,9 +148,9 @@ module.exports = function (source, options) {
   code.push('(require \'[clj-http.client :as client])\n')
 
   if (objEmpty(filterEmpty(params))) {
-    code.push('(client/%s "%s")', source.method.toLowerCase(), source.url)
+    code.push('(client/%s "%q")', source.method.toLowerCase(), source.url)
   } else {
-    code.push('(client/%s "%s" %s)', source.method.toLowerCase(), source.url, padBlock(11 + source.method.length + source.url.length, jsToEdn(filterEmpty(params))))
+    code.push('(client/%s "%q" %s)', source.method.toLowerCase(), source.url, padBlock(11 + source.method.length + source.url.length, jsToEdn(filterEmpty(params))))
   }
 
   return code.join()

--- a/src/targets/csharp/httpclient.js
+++ b/src/targets/csharp/httpclient.js
@@ -68,7 +68,7 @@ module.exports = function (source, options) {
   }
   code.push(1, 'Method = %s,', method)
 
-  code.push(1, 'RequestUri = new Uri("%s"),', source.fullUrl)
+  code.push(1, 'RequestUri = new Uri("%q"),', source.fullUrl)
 
   const headers = Object.keys(source.allHeaders).filter(function (header) {
     switch (header.toLowerCase()) {
@@ -85,7 +85,7 @@ module.exports = function (source, options) {
     code.push(1, 'Headers =')
     code.push(1, '{')
     headers.forEach(function (key) {
-      code.push(2, '{ "%s", "%s" },', key, source.allHeaders[key])
+      code.push(2, '{ "%q", "%q" },', key, source.allHeaders[key])
     })
     code.push(1, '},')
   }
@@ -97,7 +97,7 @@ module.exports = function (source, options) {
         code.push(1, 'Content = new FormUrlEncodedContent(new Dictionary<string, string>')
         code.push(1, '{')
         source.postData.params.forEach(function (param) {
-          code.push(2, '{ "%s", "%s" },', param.name, param.value)
+          code.push(2, '{ "%q", "%q" },', param.name, param.value)
         })
         code.push(1, '}),')
         break
@@ -110,13 +110,13 @@ module.exports = function (source, options) {
           code.push(3, 'Headers =')
           code.push(3, '{')
           if (param.contentType) {
-            code.push(4, 'ContentType = new MediaTypeHeaderValue("%s"),', param.contentType)
+            code.push(4, 'ContentType = new MediaTypeHeaderValue("%q"),', param.contentType)
           }
           code.push(4, 'ContentDisposition = new ContentDispositionHeaderValue("form-data")')
           code.push(4, '{')
-          code.push(5, 'Name = "%s",', param.name)
+          code.push(5, 'Name = "%q",', param.name)
           if (param.fileName) {
-            code.push(5, 'FileName = "%s",', param.fileName)
+            code.push(5, 'FileName = "%q",', param.fileName)
           }
           code.push(4, '}')
           code.push(3, '}')
@@ -130,7 +130,7 @@ module.exports = function (source, options) {
         code.push(1, '{')
         code.push(2, 'Headers =')
         code.push(2, '{')
-        code.push(3, 'ContentType = new MediaTypeHeaderValue("%s")', contentType)
+        code.push(3, 'ContentType = new MediaTypeHeaderValue("%q")', contentType)
         code.push(2, '}')
         code.push(1, '}')
         break

--- a/src/targets/csharp/restsharp.js
+++ b/src/targets/csharp/restsharp.js
@@ -10,7 +10,7 @@ module.exports = function (source, options) {
   if (methods.indexOf(source.method.toUpperCase()) === -1) {
     return 'Method not supported'
   } else {
-    code.push('var client = new RestClient("%s");', source.fullUrl)
+    code.push('var client = new RestClient("%q");', source.fullUrl)
     code.push('var request = new RestRequest(Method.%s);', source.method.toUpperCase())
   }
 
@@ -20,20 +20,20 @@ module.exports = function (source, options) {
   // construct headers
   if (headers.length) {
     headers.forEach(function (key) {
-      code.push('request.AddHeader("%s", "%s");', key, source.headersObj[key])
+      code.push('request.AddHeader("%q", "%q");', key, source.headersObj[key])
     })
   }
 
   // construct cookies
   if (source.cookies.length) {
     source.cookies.forEach(function (cookie) {
-      code.push('request.AddCookie("%s", "%s");', cookie.name, cookie.value)
+      code.push('request.AddCookie("%q", "%q");', cookie.name, cookie.value)
     })
   }
 
   if (source.postData.text) {
     code.push(
-      'request.AddParameter("%s", %s, ParameterType.RequestBody);',
+      'request.AddParameter("%q", %s, ParameterType.RequestBody);',
       helpers.getHeader(source.allHeaders, 'content-type'),
       JSON.stringify(source.postData.text)
     )

--- a/src/targets/go/native.js
+++ b/src/targets/go/native.js
@@ -93,17 +93,17 @@ module.exports = function (source, options) {
     client = 'http.DefaultClient'
   }
 
-  code.push(indent, 'url := "%s"', source.fullUrl)
+  code.push(indent, 'url := "%q"', source.fullUrl)
     .blank()
 
   // If we have body content or not create the var and reader or nil
   if (source.postData.text) {
     code.push(indent, 'payload := strings.NewReader(%s)', JSON.stringify(source.postData.text))
       .blank()
-      .push(indent, 'req, %s := http.NewRequest("%s", url, payload)', errorPlaceholder, source.method)
+      .push(indent, 'req, %s := http.NewRequest("%q", url, payload)', errorPlaceholder, source.method)
       .blank()
   } else {
-    code.push(indent, 'req, %s := http.NewRequest("%s", url, nil)', errorPlaceholder, source.method)
+    code.push(indent, 'req, %s := http.NewRequest("%q", url, nil)', errorPlaceholder, source.method)
       .blank()
   }
 
@@ -112,7 +112,7 @@ module.exports = function (source, options) {
   // Add headers
   if (Object.keys(source.allHeaders).length) {
     Object.keys(source.allHeaders).forEach(function (key) {
-      code.push(indent, 'req.Header.Add("%s", "%s")', key, source.allHeaders[key])
+      code.push(indent, 'req.Header.Add("%q", "%q")', key, source.allHeaders[key])
     })
 
     code.blank()

--- a/src/targets/java/asynchttp.js
+++ b/src/targets/java/asynchttp.js
@@ -29,7 +29,7 @@ module.exports = function (source, options) {
   // construct headers
   if (headers.length) {
     headers.forEach(function (key) {
-      code.push(1, '.setHeader("%s", "%s")', key, source.allHeaders[key])
+      code.push(1, '.setHeader("%q", "%q")', key, source.allHeaders[key])
     })
   }
 

--- a/src/targets/java/nethttp.js
+++ b/src/targets/java/nethttp.js
@@ -23,26 +23,26 @@ module.exports = function (source, options) {
   const code = new CodeBuilder(opts.indent)
 
   code.push('HttpRequest request = HttpRequest.newBuilder()')
-  code.push(2, '.uri(URI.create("%s"))', source.fullUrl)
+  code.push(2, '.uri(URI.create("%q"))', source.fullUrl)
 
   const headers = Object.keys(source.allHeaders)
 
   // construct headers
   if (headers.length) {
     headers.forEach(function (key) {
-      code.push(2, '.header("%s", "%s")', key, source.allHeaders[key])
+      code.push(2, '.header("%q", "%q")', key, source.allHeaders[key])
     })
   }
 
   if (source.postData.text) {
     code.push(
       2,
-      '.method("%s", HttpRequest.BodyPublishers.ofString(%s))',
+      '.method("%q", HttpRequest.BodyPublishers.ofString(%s))',
       source.method.toUpperCase(),
       JSON.stringify(source.postData.text)
     )
   } else {
-    code.push(2, '.method("%s", HttpRequest.BodyPublishers.noBody())', source.method.toUpperCase())
+    code.push(2, '.method("%q", HttpRequest.BodyPublishers.noBody())', source.method.toUpperCase())
   }
 
   code.push(2, '.build();')

--- a/src/targets/java/okhttp.js
+++ b/src/targets/java/okhttp.js
@@ -28,20 +28,20 @@ module.exports = function (source, options) {
 
   if (source.postData.text) {
     if (source.postData.boundary) {
-      code.push('MediaType mediaType = MediaType.parse("%s; boundary=%s");', source.postData.mimeType, source.postData.boundary)
+      code.push('MediaType mediaType = MediaType.parse("%q; boundary=%s");', source.postData.mimeType, source.postData.boundary)
     } else {
-      code.push('MediaType mediaType = MediaType.parse("%s");', source.postData.mimeType)
+      code.push('MediaType mediaType = MediaType.parse("%q");', source.postData.mimeType)
     }
     code.push('RequestBody body = RequestBody.create(mediaType, %s);', JSON.stringify(source.postData.text))
   }
 
   code.push('Request request = new Request.Builder()')
-  code.push(1, '.url("%s")', source.fullUrl)
+  code.push(1, '.url("%q")', source.fullUrl)
   if (methods.indexOf(source.method.toUpperCase()) === -1) {
     if (source.postData.text) {
-      code.push(1, '.method("%s", body)', source.method.toUpperCase())
+      code.push(1, '.method("%q", body)', source.method.toUpperCase())
     } else {
-      code.push(1, '.method("%s", null)', source.method.toUpperCase())
+      code.push(1, '.method("%q", null)', source.method.toUpperCase())
     }
   } else if (methodsWithBody.indexOf(source.method.toUpperCase()) >= 0) {
     if (source.postData.text) {
@@ -59,7 +59,7 @@ module.exports = function (source, options) {
   // construct headers
   if (headers.length) {
     headers.forEach(function (key) {
-      code.push(1, '.addHeader("%s", "%s")', key, source.allHeaders[key])
+      code.push(1, '.addHeader("%q", "%q")', key, source.allHeaders[key])
     })
   }
 

--- a/src/targets/java/unirest.js
+++ b/src/targets/java/unirest.js
@@ -22,9 +22,9 @@ module.exports = function (source, options) {
   const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
 
   if (methods.indexOf(source.method.toUpperCase()) === -1) {
-    code.push('HttpResponse<String> response = Unirest.customMethod("%s","%s")', source.method.toUpperCase(), source.fullUrl)
+    code.push('HttpResponse<String> response = Unirest.customMethod("%q","%q")', source.method.toUpperCase(), source.fullUrl)
   } else {
-    code.push('HttpResponse<String> response = Unirest.%s("%s")', source.method.toLowerCase(), source.fullUrl)
+    code.push('HttpResponse<String> response = Unirest.%s("%q")', source.method.toLowerCase(), source.fullUrl)
   }
 
   // Add headers, including the cookies
@@ -33,7 +33,7 @@ module.exports = function (source, options) {
   // construct headers
   if (headers.length) {
     headers.forEach(function (key) {
-      code.push(1, '.header("%s", "%s")', key, source.allHeaders[key])
+      code.push(1, '.header("%q", "%q")', key, source.allHeaders[key])
     })
   }
 

--- a/src/targets/kotlin/okhttp.js
+++ b/src/targets/kotlin/okhttp.js
@@ -28,20 +28,20 @@ module.exports = function (source, options) {
 
   if (source.postData.text) {
     if (source.postData.boundary) {
-      code.push('val mediaType = MediaType.parse("%s; boundary=%s")', source.postData.mimeType, source.postData.boundary)
+      code.push('val mediaType = MediaType.parse("%q; boundary=%s")', source.postData.mimeType, source.postData.boundary)
     } else {
-      code.push('val mediaType = MediaType.parse("%s")', source.postData.mimeType)
+      code.push('val mediaType = MediaType.parse("%q")', source.postData.mimeType)
     }
     code.push('val body = RequestBody.create(mediaType, %s)', JSON.stringify(source.postData.text))
   }
 
   code.push('val request = Request.Builder()')
-  code.push(1, '.url("%s")', source.fullUrl)
+  code.push(1, '.url("%q")', source.fullUrl)
   if (methods.indexOf(source.method.toUpperCase()) === -1) {
     if (source.postData.text) {
-      code.push(1, '.method("%s", body)', source.method.toUpperCase())
+      code.push(1, '.method("%q", body)', source.method.toUpperCase())
     } else {
-      code.push(1, '.method("%s", null)', source.method.toUpperCase())
+      code.push(1, '.method("%q", null)', source.method.toUpperCase())
     }
   } else if (methodsWithBody.indexOf(source.method.toUpperCase()) >= 0) {
     if (source.postData.text) {
@@ -59,7 +59,7 @@ module.exports = function (source, options) {
   // construct headers
   if (headers.length) {
     headers.forEach(function (key) {
-      code.push(1, '.addHeader("%s", "%s")', key, source.allHeaders[key])
+      code.push(1, '.addHeader("%q", "%q")', key, source.allHeaders[key])
     })
   }
 

--- a/src/targets/node/native.js
+++ b/src/targets/node/native.js
@@ -32,7 +32,7 @@ module.exports = function (source, options) {
     reqOpts.rejectUnauthorized = false
   }
 
-  code.push('const http = require("%s");', source.uriObj.protocol.replace(':', ''))
+  code.push('const http = require("%q");', source.uriObj.protocol.replace(':', ''))
 
   code.blank()
     .push('const options = %s;', JSON.stringify(reqOpts, null, opts.indent))

--- a/src/targets/node/unirest.js
+++ b/src/targets/node/unirest.js
@@ -22,14 +22,14 @@ module.exports = function (source, options) {
 
   code.push('const unirest = require("unirest");')
     .blank()
-    .push('const req = unirest("%s", "%s");', source.method, source.url)
+    .push('const req = unirest("%q", "%q");', source.method, source.url)
     .blank()
 
   if (source.cookies.length) {
     code.push('const CookieJar = unirest.jar();')
 
     source.cookies.forEach(function (cookie) {
-      code.push('CookieJar.add("%s=%s","%s");', encodeURIComponent(cookie.name), encodeURIComponent(cookie.value), source.url)
+      code.push('CookieJar.add("%q=%s","%q");', encodeURIComponent(cookie.name), encodeURIComponent(cookie.value), source.url)
     })
 
     code.push('req.jar(CookieJar);')

--- a/src/targets/objc/nsurlsession.js
+++ b/src/targets/objc/nsurlsession.js
@@ -45,11 +45,11 @@ module.exports = function (source, options) {
         // we make it easier for the user to edit it according to his or her needs after pasting.
         // The user can just add/remove lines adding/removing body parameters.
         code.blank()
-          .push('NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"%s=%s" dataUsingEncoding:NSUTF8StringEncoding]];',
+          .push('NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"%q=%s" dataUsingEncoding:NSUTF8StringEncoding]];',
             source.postData.params[0].name, source.postData.params[0].value)
 
         for (let i = 1, len = source.postData.params.length; i < len; i++) {
-          code.push('[postData appendData:[@"&%s=%s" dataUsingEncoding:NSUTF8StringEncoding]];',
+          code.push('[postData appendData:[@"&%q=%s" dataUsingEncoding:NSUTF8StringEncoding]];',
             source.postData.params[i].name, source.postData.params[i].value)
         }
         break
@@ -67,7 +67,7 @@ module.exports = function (source, options) {
         // we make it easier for the user to edit it according to his or her needs after pasting.
         // The user can just edit the parameters NSDictionary or put this part of a snippet in a multipart builder method.
         code.push(helpers.nsDeclaration('NSArray', 'parameters', source.postData.params, opts.pretty))
-          .push('NSString *boundary = @"%s";', source.postData.boundary)
+          .push('NSString *boundary = @"%q";', source.postData.boundary)
           .blank()
           .push('NSError *error;')
           .push('NSMutableString *body = [NSMutableString string];')

--- a/src/targets/ocaml/cohttp.js
+++ b/src/targets/ocaml/cohttp.js
@@ -24,18 +24,18 @@ module.exports = function (source, options) {
     .push('open Cohttp')
     .push('open Lwt')
     .blank()
-    .push('let uri = Uri.of_string "%s" in', source.fullUrl)
+    .push('let uri = Uri.of_string "%q" in', source.fullUrl)
 
   // Add headers, including the cookies
   const headers = Object.keys(source.allHeaders)
 
   if (headers.length === 1) {
-    code.push('let headers = Header.add (Header.init ()) "%s" "%s" in', headers[0], source.allHeaders[headers[0]])
+    code.push('let headers = Header.add (Header.init ()) "%q" "%q" in', headers[0], source.allHeaders[headers[0]])
   } else if (headers.length > 1) {
     code.push('let headers = Header.add_list (Header.init ()) [')
 
     headers.forEach(function (key) {
-      code.push(1, '("%s", "%s");', key, source.allHeaders[key])
+      code.push(1, '("%q", "%q");', key, source.allHeaders[key])
     })
 
     code.push('] in')

--- a/src/targets/powershell/common.js
+++ b/src/targets/powershell/common.js
@@ -22,7 +22,7 @@ module.exports = function (command) {
       code.push('$headers=@{}')
       headers.forEach(function (key) {
         if (key !== 'connection') { // Not allowed
-          code.push('$headers.Add("%s", "%s")', key, source.headersObj[key])
+          code.push('$headers.Add("%q", "%q")', key, source.headersObj[key])
         }
       })
       commandOptions.push('-Headers $headers')

--- a/src/targets/python/python3.js
+++ b/src/targets/python/python3.js
@@ -28,15 +28,15 @@ module.exports = function (source, options) {
   if (protocol === 'https:') {
     if (options.insecureSkipVerify) {
       code.push(
-        'conn = http.client.HTTPSConnection("%s", context = ssl._create_unverified_context())',
+        'conn = http.client.HTTPSConnection("%q", context = ssl._create_unverified_context())',
         source.uriObj.host
       ).blank()
     } else {
-      code.push('conn = http.client.HTTPSConnection("%s")', source.uriObj.host)
+      code.push('conn = http.client.HTTPSConnection("%q")', source.uriObj.host)
         .blank()
     }
   } else {
-    code.push('conn = http.client.HTTPConnection("%s")', source.uriObj.host)
+    code.push('conn = http.client.HTTPConnection("%q")', source.uriObj.host)
       .blank()
   }
 
@@ -52,7 +52,7 @@ module.exports = function (source, options) {
   const headerCount = Object.keys(headers).length
   if (headerCount === 1) {
     for (const header in headers) {
-      code.push('headers = { "%s": "%s" }', header, headers[header])
+      code.push('headers = { "%q": "%q" }', header, headers[header])
         .blank()
     }
   } else if (headerCount > 1) {
@@ -62,9 +62,9 @@ module.exports = function (source, options) {
 
     for (const header in headers) {
       if (count++ !== headerCount) {
-        code.push('    "%s": "%s",', header, headers[header])
+        code.push('    "%q": "%q",', header, headers[header])
       } else {
-        code.push('    "%s": "%s"', header, headers[header])
+        code.push('    "%q": "%q"', header, headers[header])
       }
     }
 
@@ -76,13 +76,13 @@ module.exports = function (source, options) {
   const method = source.method
   const path = source.uriObj.path
   if (payload && headerCount) {
-    code.push('conn.request("%s", "%s", payload, headers)', method, path)
+    code.push('conn.request("%q", "%q", payload, headers)', method, path)
   } else if (payload && !headerCount) {
-    code.push('conn.request("%s", "%s", payload)', method, path)
+    code.push('conn.request("%q", "%q", payload)', method, path)
   } else if (!payload && headerCount) {
-    code.push('conn.request("%s", "%s", headers=headers)', method, path)
+    code.push('conn.request("%q", "%q", headers=headers)', method, path)
   } else {
-    code.push('conn.request("%s", "%s")', method, path)
+    code.push('conn.request("%q", "%q")', method, path)
   }
 
   // Get Response

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -38,7 +38,7 @@ module.exports = function (source, options) {
     .blank()
 
   // Set URL
-  code.push('url = "%s"', source.url)
+  code.push('url = "%q"', source.url)
     .blank()
 
   // Construct query string
@@ -85,7 +85,7 @@ module.exports = function (source, options) {
 
   if (headerCount === 1) {
     for (const header in headers) {
-      code.push('headers = { "%s": "%s" }', header, headers[header])
+      code.push('headers = { "%q": "%q" }', header, headers[header])
         .blank()
     }
   } else if (headerCount > 1) {
@@ -95,9 +95,9 @@ module.exports = function (source, options) {
 
     for (const header in headers) {
       if (count++ !== headerCount) {
-        code.push(1, '"%s": "%s",', header, headers[header])
+        code.push(1, '"%q": "%q",', header, headers[header])
       } else {
-        code.push(1, '"%s": "%s"', header, headers[header])
+        code.push(1, '"%q": "%q"', header, headers[header])
       }
     }
 

--- a/src/targets/r/httr.js
+++ b/src/targets/r/httr.js
@@ -22,7 +22,7 @@ module.exports = function (source, options) {
     .blank()
 
   // Set URL
-  code.push('url <- "%s"', source.url)
+  code.push('url <- "%q"', source.url)
     .blank()
 
   // Construct query string
@@ -31,7 +31,7 @@ module.exports = function (source, options) {
   delete source.queryObj.key
 
   if (source.queryString.length === 1) {
-    code.push('queryString <- list(%s = "%s")', Object.keys(qs), Object.values(qs).toString())
+    code.push('queryString <- list(%s = "%q")', Object.keys(qs), Object.values(qs).toString())
       .blank()
   } else if (source.queryString.length > 1) {
     let count = 1
@@ -40,9 +40,9 @@ module.exports = function (source, options) {
 
     for (const query in qs) {
       if (count++ !== queryCount - 1) {
-        code.push('  %s = "%s",', query, qs[query].toString())
+        code.push('  %s = "%q",', query, qs[query].toString())
       } else {
-        code.push('  %s = "%s"', query, qs[query].toString())
+        code.push('  %s = "%q"', query, qs[query].toString())
       }
     }
 

--- a/src/targets/ruby/native.js
+++ b/src/targets/ruby/native.js
@@ -28,7 +28,7 @@ module.exports = function (source, options) {
       .blank()
   }
 
-  code.push('url = URI("%s")', source.fullUrl)
+  code.push('url = URI("%q")', source.fullUrl)
     .blank()
     .push('http = Net::HTTP.new(url.host, url.port)')
 
@@ -46,7 +46,7 @@ module.exports = function (source, options) {
   const headers = Object.keys(source.allHeaders)
   if (headers.length) {
     headers.forEach(function (key) {
-      code.push('request["%s"] = \'%s\'', key, source.allHeaders[key])
+      code.push('request["%q"] = \'%s\'', key, source.allHeaders[key])
     })
   }
 

--- a/src/targets/swift/nsurlsession.js
+++ b/src/targets/swift/nsurlsession.js
@@ -46,9 +46,9 @@ module.exports = function (source, options) {
         // we make it easier for the user to edit it according to his or her needs after pasting.
         // The user can just add/remove lines adding/removing body parameters.
         code.blank()
-          .push('let postData = NSMutableData(data: "%s=%s".data(using: String.Encoding.utf8)!)', source.postData.params[0].name, source.postData.params[0].value)
+          .push('let postData = NSMutableData(data: "%q=%s".data(using: String.Encoding.utf8)!)', source.postData.params[0].name, source.postData.params[0].value)
         for (let i = 1, len = source.postData.params.length; i < len; i++) {
-          code.push('postData.append("&%s=%s".data(using: String.Encoding.utf8)!)', source.postData.params[i].name, source.postData.params[i].value)
+          code.push('postData.append("&%q=%s".data(using: String.Encoding.utf8)!)', source.postData.params[i].name, source.postData.params[i].value)
         }
         break
 
@@ -68,7 +68,7 @@ module.exports = function (source, options) {
         */
         code.push(helpers.literalDeclaration('parameters', source.postData.params, opts))
           .blank()
-          .push('let boundary = "%s"', source.postData.boundary)
+          .push('let boundary = "%q"', source.postData.boundary)
           .blank()
           .push('var body = ""')
           .push('var error: NSError? = nil')
@@ -93,16 +93,16 @@ module.exports = function (source, options) {
 
       default:
         code.blank()
-          .push('let postData = NSData(data: "%s".data(using: String.Encoding.utf8)!)', source.postData.text)
+          .push('let postData = NSData(data: "%q".data(using: String.Encoding.utf8)!)', source.postData.text)
     }
   }
 
   code.blank()
     // NSURLRequestUseProtocolCachePolicy is the default policy, let's just always set it to avoid confusion.
-    .push('let request = NSMutableURLRequest(url: NSURL(string: "%s")! as URL,', source.fullUrl)
+    .push('let request = NSMutableURLRequest(url: NSURL(string: "%q")! as URL,', source.fullUrl)
     .push('                                        cachePolicy: .useProtocolCachePolicy,')
     .push('                                    timeoutInterval: %s)', parseInt(opts.timeout, 10).toFixed(1))
-    .push('request.httpMethod = "%s"', source.method)
+    .push('request.httpMethod = "%q"', source.method)
 
   if (req.hasHeaders) {
     code.push('request.allHTTPHeaderFields = headers')


### PR DESCRIPTION
### What I did:
- Rewrote found classes into ES6 standard
- Added some new handy methods to CodeBuilder class, so that you can control indentation easier (an example will in another pull request with Reqwest target for Rustm which I'll upload later)
- Added `%q` (escape quotes and other special characters) and `%v` (stringify json) options in format. Before each call used `%s`, so in many cases it led to unescaped quotes.
- Tried to replace `%s` to `%q` where seems appropriate. Used VSCode replace functionality and Regex, tried to do as accurately, as I can. Still passing tests, so I hope I did it completely. Won't be worse in any case.