### PR TITLE
Add %v and %q options to format in CodeBuilder.buildLine and some handy indentation methods

### DIFF
--- a/src/helpers/code-builder.js
+++ b/src/helpers/code-builder.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const util = require('util')
+const formatString = require('./format')
 
 /**
  * Helper object to format and aggragate lines of code.
@@ -13,6 +13,7 @@ const util = require('util')
  */
 const CodeBuilder = function (indentation, join) {
   this.code = []
+  this.indentLevel = 0
   this.indentation = indentation
   this.lineJoin = join || '\n'
 }
@@ -42,7 +43,7 @@ CodeBuilder.prototype.buildLine = function (indentationLevel, line) {
   if (Object.prototype.toString.call(indentationLevel) === '[object String]') {
     slice = 1
     line = indentationLevel
-    indentationLevel = 0
+    indentationLevel = this.indentLevel
   } else if (indentationLevel === null) {
     return null
   }
@@ -55,7 +56,7 @@ CodeBuilder.prototype.buildLine = function (indentationLevel, line) {
   const format = Array.prototype.slice.call(arguments, slice, arguments.length)
   format.unshift(lineIndentation + line)
 
-  return util.format.apply(this, format)
+  return formatString.apply(this, format)
 }
 
 /**
@@ -98,6 +99,33 @@ CodeBuilder.prototype.blank = function () {
  */
 CodeBuilder.prototype.join = function () {
   return this.code.join(this.lineJoin)
+}
+
+/**
+ * Increase indentation level
+ * @returns {this}
+ */
+CodeBuilder.prototype.indent = function () {
+  this.indentLevel++
+  return this
+}
+
+/**
+ * Decrease indentation level
+ * @returns {this}
+ */
+CodeBuilder.prototype.unindent = function () {
+  this.indentLevel--
+  return this
+}
+
+/**
+ * Reset indentation level
+ * @returns {this}
+ */
+CodeBuilder.prototype.reindent = function () {
+  this.indentLevel = 0
+  return this
 }
 
 module.exports = CodeBuilder

--- a/src/helpers/format.js
+++ b/src/helpers/format.js
@@ -1,0 +1,53 @@
+const util = require('util')
+
+function quote (value) {
+  if (typeof value !== 'string') value = JSON.stringify(value)
+  return JSON.stringify(value)
+}
+
+function escape (value) {
+  const q = quote(value)
+  return q && q.slice(1, -1)
+}
+
+/**
+ * Wraps the `util.format` function and adds the %q and %v format options,
+ * where `%q` - escape tricky characters, like newline or quotes
+ * and `%v` - JSON-stringify-if-necessary
+ *
+ * @param {string} value
+ * @param  {...string} format
+ *
+ * @example
+ * format('foo("%q")', { bar: 'baz' })
+ * // output: foo("{\"bar\":\"baz\"}")
+ *
+ * format('foo(%v)', { bar: 'baz' })
+ * // output: foo({"bar":"baz"})
+ *
+ * @returns {string} Formatted string
+ */
+function format (value, ...format) {
+  if (typeof value !== 'string') return ''
+
+  let i = 0
+  value = value.replace(/(?<!%)%[sdifjoOcqv]/g, (m) => {
+    // JSON-stringify
+    if (m === '%v') {
+      const [elem] = format.splice(i, 1)
+      return JSON.stringify(elem)
+    }
+    // JSON-stringify, remove quotes (means, escape)
+    if (m === '%q') {
+      const [elem] = format.splice(i, 1)
+      return escape(elem)
+    }
+    i += 1
+    return m
+  })
+
+  const ret = util.format(value, ...format)
+  return ret
+}
+
+module.exports = format


### PR DESCRIPTION
1. Added `%v` and `%q` options to format in `CodeBuilder.buildLine`. Why? When I implemented Rust's Reqwest target (I'll make the corresponding Pull Request after this one), I noticed the problem of escaping characters. For example, my chrome browser generates `sec-ch-ua` header, that contains quotes, and some of the targets do not escape them, which results in broken code. And also I'm using it in the mentioned Reqwest target.
2. Added `indent`, `unindent` and `reindent` methods to `CodeBuilder`, as it allows to control indentation more conveniently.

### How do `%v` and `%q` options work?
Right from the comments I made to the new `format` function:

> Wraps the util.format function and adds the %q and %v format options, where %q - escape tricky characters, like newline or quotes and %v - JSON-stringify-if-necessary

Examples:
```js
format('foo("%q")', { bar: 'baz' })
// output: foo("{\"bar\":\"baz\"}")

format('foo("%q")', `
`)
// output: foo("\n")

format('foo(%v)', { bar: 'baz' })
// output: foo({"bar":"baz"})

format('foo(%s)', { bar: 'baz' })
// output: foo({ bar: 'baz' })
```