### PR TITLE
Change variable name in rest parameter due to error in safari

### DIFF
--- a/src/helpers/format.js
+++ b/src/helpers/format.js
@@ -63,30 +63,30 @@ function singleQuoteEscape (value) {
  *
  * @returns {string} Formatted string
  */
-exports.format = function format (value, ...format) {
+exports.format = function format (value, ...formatVariables) {
   if (typeof value !== 'string') return ''
 
   let i = 0
   value = value.replace(/(?<!%)%([sdifjoOcv]|q[sd])/g, (m) => {
     // JSON-stringify
     if (m === '%v') {
-      const [elem] = format.splice(i, 1)
+      const [elem] = formatVariables.splice(i, 1)
       return JSON.stringify(elem)
     }
     // Escape for double-quoted string
     if (m === '%qd') {
-      const [elem] = format.splice(i, 1)
+      const [elem] = formatVariables.splice(i, 1)
       return doubleQuoteEscape(elem)
     }
     // Escape for single-quoted string
     if (m === '%qs') {
-      const [elem] = format.splice(i, 1)
+      const [elem] = formatVariables.splice(i, 1)
       return singleQuoteEscape(elem)
     }
     i += 1
     return m
   })
 
-  const ret = util.format(value, ...format)
+  const ret = util.format(value, ...formatVariables)
   return ret
 }


### PR DESCRIPTION
![http192 168 7 1553000](https://user-images.githubusercontent.com/13029040/177641581-1e636093-a183-417a-ad8d-a74c16565d1b.jpeg)


On iOS safari, it complains due to the rest parameter having the same name as the function name