### PR TITLE
Check if options is defined before accessing insecureSkipVerify

### DIFF
--- a/src/targets/node/native.js
+++ b/src/targets/node/native.js
@@ -28,7 +28,7 @@ module.exports = function (source, options) {
     headers: source.allHeaders
   }
 
-  if (options.insecureSkipVerify) {
+  if (options && options.insecureSkipVerify) {
     reqOpts.rejectUnauthorized = false
   }
 


### PR DESCRIPTION
 The `insecureSkipVerify` property was being accessed on the `options` object without checking if `options` was defined, leading to a TypeError when `options` was undefined.

````bash
Error stack trace:
TypeError: Cannot read properties of undefined (reading 'insecureSkipVerify')
    ...