### PR TITLE
Fix JSON parsing for python requests

### DIFF
--- a/src/targets/python/helpers.js
+++ b/src/targets/python/helpers.js
@@ -77,7 +77,7 @@ module.exports = {
         if (value === null || value === undefined) {
           return ''
         }
-        return '"' + value.toString().replace(/"/g, '\\"') + '"'
+        return JSON.stringify(value)
     }
   }
 }

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -56,7 +56,7 @@ module.exports = function (source, options) {
   switch (source.postData.mimeType) {
     case 'application/json':
       if (source.postData.jsonObj) {
-        code.push('payload = %s', helpers.literalRepresentation(source.postData.jsonObj, opts))
+        code.push('payload = %s', JSON.stringify(source.postData.jsonObj))
         jsonPayload = true
         hasPayload = true
       }

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -56,7 +56,7 @@ module.exports = function (source, options) {
   switch (source.postData.mimeType) {
     case 'application/json':
       if (source.postData.jsonObj) {
-        code.push('payload = %s', JSON.stringify(source.postData.jsonObj))
+        code.push('payload = %s', helpers.literalRepresentation(source.postData.jsonObj, opts))
         jsonPayload = true
         hasPayload = true
       }


### PR DESCRIPTION
**Problem**
JSON payload for python requests client is not parsed correctly. Specifically, this payload:

```json
{
    "method": "POST",
    "url": "http://mockbin.com/har",
    "httpVersion": "HTTP/1.1",
    "cookies": [],
    "headers": [
        {
            "name": "content-type",
            "value": "application/json"
        }
    ],
    "queryString": [],
    "postData": {
        "mimeType": "application/json",
        "text": "{\"field\":\"value{\\n n1 \"}"
    }
}
```

will result in this output

```python
import requests

url = "http://mockbin.com/har"

payload = { "field": "value{
 n1 " }
headers = { "content-type": "application/json" }

response = requests.post(url, json=payload, headers=headers)

print(response.text)
```


Problem is caused by the `{\\n` and `\"`.

**Solution**
Used JSON.stringify to convert the jsonObj to string.

Results in correct output:

```python
import requests

url = "http://mockbin.com/har"

payload = {"field":"value{\n n1 "}
headers = { "content-type": "application/json" }

response = requests.post(url, json=payload, headers=headers)

print(response.text)
```

Indentation can also be added by passing appropriate arguments to JSON.stringify.